### PR TITLE
Remove the non-existent default title feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,6 @@ Use `meteor add ahref:flow-router-breadcrumb` to add the package to your meteor 
 ### In this example the Breadcrumb would look or the url `/dashboard/analytics/books` like: `Dashboard / Analytics / Category Books`
 
 ```
-// Default title
-FlowRouter.configure({
-  title: 'My Site'
-});
-
 // Level 0
 FlowRouter.route('/', {
   name: 'dashboard',


### PR DESCRIPTION
I see this was copypasted from Iron Router's package documentation, but (sadly) it's not available in Flow Router which doesn't provide such api and returns "TypeError: FlowRouter.configure is not a function" message.
