### PR TITLE
add desluggify feature for title

### DIFF
--- a/lib/breadcrumb.js
+++ b/lib/breadcrumb.js
@@ -20,6 +20,8 @@ var enrichRouteObject = function(routeName, isCurrent) {
       title = title && title.replace(
         new RegExp((':'+i).replace(/\+/g, "\\+"), "g"), params[i]);
     }
+    if (routeOptions.slug)
+      title = title.split(routeOptions.slug).join(' ');
     if (!getRouteByName(routeName).options.noCaps)
       title = title && title.capitalize();
   } else {


### PR DESCRIPTION
It's a common thing to provide a slug of a title/name of document in route. This leads to breadcrumb in a form:

```
level 1 > My-awesome-title > level 3
```

What we usually want is for that to look like:

```
level 1 > My Awesome Title > level 3
```

With this patch, user can specify a slug character that was used in the slug. So if we have:

```
title: ':param',
slug: '-'
```

All the '-' characters in the title will be changed into ' ' and the title will get capitalized as usual.
