### PR TITLE
Update readme: missed documentation for usage functions as value for title and parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ FlowRouter.route('/post/:_name', {
       }
       return "post.yesterday";
   }, 
-  title: function(){// We can use function as 
+  title: function(){// We can use function here
      return ":_name" + getPostTime(this); //some function to return formatted post time    
   } 
 });

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ FlowRouter.route('/post/:_name', {
 });
 ```
 
-### In this example the Breadcrumb would look for the url `/post/today-post` (`/post/yesterday-post`) like: `Today Posts / Today Post 15:50` (`Yesterday Posts / Yesterday Post 15:50`) 
+### In this example the Breadcrumb would be `Today Posts / Today Post 15:50` for url `/post/today-post`. And would be `Yesterday Posts / Yesterday Post 15:50` for url  `/post/yesterday-post` 
 
 ```javascript
 FlowRouter.route('/today', {
@@ -97,7 +97,7 @@ FlowRouter.route('/post/:_name', {
       return "post.yesterday";
   }, 
   title: function(){// We can use function as 
-     return ":_name" + getPostTime(this.); //some function to return formatted post time    
+     return ":_name" + getPostTime(this); //some function to return formatted post time    
   } 
 });
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ FlowRouter.route('/post/:_name', {
 });
 ```
 
+### In this example the Breadcrumb would look for the url `/post/today-post` (`/post/yesterday-post`) like: `Today Posts / Today Post 15:50` (`Yesterday Posts / Yesterday Post 15:50`) 
+
+```javascript
+FlowRouter.route('/today', {
+  name: 'post.today',
+  template: 'todayPosts',
+  title: 'Today posts'
+});
+
+FlowRouter.route('/yesterday', {
+  name: 'post.yesterday',
+  template: 'yesterdayPosts',
+  title: 'Yesterday posts'
+});
+
+FlowRouter.route('/post/:_name', {
+  name: 'post',
+  parent: function(){// we can use  function to determine parent. "this" value will be FlowRouter.current()
+    if (isTodayPost()){//some function to detect time of post
+        return "post.today";
+      }
+      return "post.yesterday";
+  }, 
+  title: function(){// We can use function as 
+     return ":_name" + getPostTime(this.); //some function to return formatted post time    
+  } 
+});
+```
+
 ## 3. Example use of the de-slugify feature
 ```
 It's a common thing to provide a slug of a title/name of document in route. This leads to breadcrumb in a form:


### PR DESCRIPTION
That part not exists in documentation, but that feature is very useful in some cases.
